### PR TITLE
Fix indentation and change documentation theme

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ mkdocs:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
  python:
     install:
-    - requirements: docs/requirements.txt
+      - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ mkdocs:
 # Optionally, but recommended,
 # declare the Python requirements required to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
- python:
-    install:
-      - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ nav:
       - View: view.md
       - Controller: controller.md
 theme:
-  name: mkdocs
+  name: readthedocs
 plugins:
   - search
   - mkdocstrings:


### PR DESCRIPTION
Correct indentation in the `.readthedocs.yaml` file and update the theme from `mkdocs` to `readthedocs`.